### PR TITLE
Add TTS voice channel support with local voice synthesis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.7.9",
         "discord.js": "^14.17.3",
         "ffmpeg-static": "^5.2.0",
+        "form-data": "^4.0.1",
         "libsodium-wrappers": "^0.7.15"
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.7.9",
     "discord.js": "^14.17.3",
     "ffmpeg-static": "^5.2.0",
+    "form-data": "^4.0.1",
     "libsodium-wrappers": "^0.7.15"
   }
 }

--- a/tts_handler.js
+++ b/tts_handler.js
@@ -7,6 +7,7 @@ const {
 const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
+const FormData = require('form-data');
 
 class TTSHandler {
     constructor() {
@@ -37,9 +38,14 @@ class TTSHandler {
 
         try {
             // Call the TTS server
+            const formData = new FormData();
+            formData.append('text', text);
             const response = await axios.post('http://localhost:8000/tts/', 
-                { text },
-                { responseType: 'arraybuffer' }
+                formData,
+                { 
+                    responseType: 'arraybuffer',
+                    headers: formData.getHeaders()
+                }
             );
 
             // Save the audio to a temporary file

--- a/tts_server/requirements.txt
+++ b/tts_server/requirements.txt
@@ -1,6 +1,4 @@
-fastapi
-uvicorn
-python-multipart
+flask
 numpy
 torch
 torchaudio


### PR DESCRIPTION
This PR adds Text-to-Speech functionality to the Discord bot with the following features:

- Connects to specified voice channel on startup
- Uses local TTS server with Facebook MMS-TTS model
- Speaks responses in voice channel while still sending text messages
- Improved Python 3.12 compatibility using Flask

Changes include:
- Added TTS server using Flask and Facebook MMS-TTS model
- Created TTS handler for Discord voice channel integration
- Updated bot to support simultaneous text and voice responses
- Added necessary dependencies for voice and TTS functionality

To run:
1. Start TTS server: `cd tts_server && python tts_server.py`
2. Start Discord bot: `node index.js`