### PR TITLE
Switch to ElevenLabs TTS

### DIFF
--- a/tts_server/.env.sample
+++ b/tts_server/.env.sample
@@ -1,0 +1,1 @@
+ELEVENLABS_API_KEY=your_api_key_here

--- a/tts_server/requirements.txt
+++ b/tts_server/requirements.txt
@@ -1,8 +1,3 @@
 flask
-numpy
-torch
-torchaudio
-soundfile
-TTS
-scipy
-unidecode
+elevenlabs
+python-dotenv


### PR DESCRIPTION
This PR replaces the current local TTS system with ElevenLabs integration for better voice quality and more features.

### Changes
- Replace local TTS with ElevenLabs API integration
- Add voice cloning support through ElevenLabs
- Update requirements.txt with new dependencies
- Add environment variable support for API key

### Setup Instructions
1. Copy `.env.sample` to `.env` in the tts_server directory
2. Add your ElevenLabs API key to the `.env` file
3. Install new dependencies: `pip install -r requirements.txt`

### API Changes
- Voice cloning now returns a voice_id for use in TTS requests
- /tts/voices endpoint returns available ElevenLabs voices
- Default voice is "Rachel" if no voice_id is provided