### PR TITLE
Fix missing catch block in TTS handler

### DIFF
--- a/tts_handler.js
+++ b/tts_handler.js
@@ -91,6 +91,9 @@ class TTSHandler {
                         resolve(false);
                     });
                 });
+            } catch (error) {
+                console.error('Error creating or playing audio resource:', error);
+                return false;
             }
         } catch (error) {
             console.error('Error in TTS:', error);


### PR DESCRIPTION
This PR fixes a syntax error in `tts_handler.js` where a try block was missing its corresponding catch block. The fix adds proper error handling for audio resource creation and playback operations.

Changes:
- Added catch block for the inner try block in the `speak` method
- Added error logging for audio resource creation and playback issues