### PR TITLE
Fix TTS audio playback

### DIFF
--- a/tts_handler.js
+++ b/tts_handler.js
@@ -55,9 +55,12 @@ class TTSHandler {
             );
 
             try {
-                // Create an audio resource directly from the response data
-                const audioBuffer = Buffer.from(response.data);
-                const resource = createAudioResource(audioBuffer, {
+                // Save the audio buffer to a temporary file
+                const tempFile = path.join(__dirname, `temp_${Date.now()}.mp3`);
+                fs.writeFileSync(tempFile, response.data);
+
+                // Create an audio resource from the file
+                const resource = createAudioResource(tempFile, {
                     inputType: 'mp3',
                     inlineVolume: true
                 });
@@ -73,14 +76,26 @@ class TTSHandler {
                 
                 this.player.on(AudioPlayerStatus.Idle, () => {
                     console.log('Audio player is now idle');
+                    // Clean up the temporary file
+                    try {
+                        fs.unlinkSync(tempFile);
+                    } catch (err) {
+                        console.error('Error cleaning up temp file:', err);
+                    }
                 });
                 
                 this.player.on('error', error => {
                     console.error('Error in audio player:', error);
+                    // Clean up the temporary file on error
+                    try {
+                        fs.unlinkSync(tempFile);
+                    } catch (err) {
+                        console.error('Error cleaning up temp file:', err);
+                    }
                 });
 
                 this.player.play(resource);
-                console.log('Attempting to play audio resource');
+                console.log('Attempting to play audio resource from file:', tempFile);
 
                 return new Promise((resolve) => {
                     this.player.once(AudioPlayerStatus.Idle, () => {


### PR DESCRIPTION
This PR fixes the TTS audio playback issues by:

1. Saving the audio to a temporary file before playing
2. Creating the audio resource from the file instead of directly from a buffer
3. Adding proper cleanup of temporary files
4. Adding more detailed logging for debugging

These changes should improve playback reliability since @discordjs/voice works better with files than with buffers.