### PR TITLE
Add voice channel user detection for TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ node index.js
 
 ### Text-to-Speech (TTS)
 - Real-time voice synthesis in voice channels
-- Voice cloning capability using YourTTS
+- Voice cloning capability using ElevenLabs
 - Multiple voice profile support
-- Speaks responses while also sending text messages
+- Speaks responses only when users are present in the voice channel
+- Automatically skips TTS when voice channel is empty
+- Sends text messages regardless of TTS status
 
 ## Commands
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -337,7 +337,9 @@ class DiscordBot {
 
             // Then speak the response if TTS is enabled
             if (this.ttsHandler.isEnabled()) {
-                await this.ttsHandler.speak(response);
+                const guild = this.client.guilds.cache.get(config.TARGET_GUILD_ID);
+                const voiceChannel = guild?.channels.cache.get(config.VOICE_CHANNEL_ID);
+                await this.ttsHandler.speak(response, voiceChannel);
             }
 
         } catch (error) {

--- a/tts_handler.js
+++ b/tts_handler.js
@@ -40,8 +40,14 @@ class TTSHandler {
         }
     }
 
-    async speak(text) {
+    async speak(text, channel) {
         if (!this.connection) return false;
+
+        // Check if there are users in the voice channel
+        if (!channel || channel.members.size <= 1) {  // <= 1 because the bot counts as a member
+            console.log('No users in voice channel, skipping TTS');
+            return false;
+        }
 
         try {
             // Call ElevenLabs API directly


### PR DESCRIPTION
This PR adds voice channel user detection to make TTS more efficient by only sending messages to ElevenLabs when there are users in the voice channel.

### Changes
- Modified TTS handler to check for users in voice channel before sending TTS requests
- Updated bot.js to pass voice channel information to TTS handler
- Updated README to accurately reflect current TTS behavior and ElevenLabs integration

### Testing
- TTS will only be triggered when users are present in the voice channel
- Text messages will still be sent regardless of voice channel status
- TTS will automatically skip when voice channel is empty