### PR TITLE
Add music playlist feature with worker bot

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,10 +1,13 @@
 {
     "DISCORD_TOKEN": "",
+    "MUSIC_BOT_TOKEN": "",
     "MSTY_API_URL": "http://localhost:1234",
     "TARGET_GUILD_ID": "",
     "TARGET_CHANNEL_ID": "",
     "VOICE_CHANNEL_ID": "",
     "MEMORY_LIMIT": 10,
     "BING_API_KEY": "",
-    "BING_ENDPOINT": "https://api.bing.microsoft.com/v7.0/search"
+    "BING_ENDPOINT": "https://api.bing.microsoft.com/v7.0/search",
+    "SPOTIFY_CLIENT_ID": "",
+    "SPOTIFY_CLIENT_SECRET": ""
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "ffmpeg-static": "^5.2.0",
     "form-data": "^4.0.1",
     "libsodium-wrappers": "^0.7.15",
-    "sodium-native": "^4.3.1"
+    "play-dl": "^1.9.7",
+    "sodium-native": "^4.3.1",
+    "spotify-web-api-node": "^5.0.2"
   }
 }

--- a/src/bot.js
+++ b/src/bot.js
@@ -4,12 +4,13 @@ const { replaceUserMentions, getRandomGif } = require('./utils');
 const axios = require('axios');
 
 class DiscordBot {
-    constructor(memoryManager, textProcessor, imageProcessor, commandManager, ttsHandler) {
+    constructor(memoryManager, textProcessor, imageProcessor, commandManager, ttsHandler, musicModule) {
         this.memoryManager = memoryManager;
         this.textProcessor = textProcessor;
         this.imageProcessor = imageProcessor;
         this.commandManager = commandManager;
         this.ttsHandler = ttsHandler;
+        this.musicModule = musicModule;
         this.processingUsers = new Set(); // Track users with ongoing message processing
 
         this.client = new Client({
@@ -107,6 +108,12 @@ class DiscordBot {
                 );
 
                 await interaction.editReply(response);
+                return;
+            }
+
+            // Music commands
+            if (['play', 'skip', 'stop', 'queue'].includes(interaction.commandName)) {
+                await this.musicModule.handleCommand(interaction, interaction.commandName);
                 return;
             }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -39,6 +39,90 @@ class CommandManager {
 
     getSlashCommands() {
         return [
+            // Music commands
+            new SlashCommandBuilder()
+                .setName('play')
+                .setDescription('Play a song')
+                .addStringOption(option =>
+                    option.setName('query')
+                        .setDescription('The song to play (URL or search query)')
+                        .setRequired(true)),
+            new SlashCommandBuilder()
+                .setName('skip')
+                .setDescription('Skip the current song'),
+            new SlashCommandBuilder()
+                .setName('stop')
+                .setDescription('Stop playback and clear the queue'),
+            new SlashCommandBuilder()
+                .setName('queue')
+                .setDescription('Show the current music queue'),
+            new SlashCommandBuilder()
+                .setName('playlist')
+                .setDescription('Manage your playlists')
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName('create')
+                        .setDescription('Create a new playlist')
+                        .addStringOption(option =>
+                            option.setName('name')
+                                .setDescription('Name of the playlist')
+                                .setRequired(true))
+                        .addStringOption(option =>
+                            option.setName('description')
+                                .setDescription('Description of the playlist')
+                                .setRequired(false)))
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName('add')
+                        .setDescription('Add a track to a playlist')
+                        .addStringOption(option =>
+                            option.setName('name')
+                                .setDescription('Name of the playlist')
+                                .setRequired(true))
+                        .addStringOption(option =>
+                            option.setName('query')
+                                .setDescription('Track to add (URL or search query)')
+                                .setRequired(true)))
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName('remove')
+                        .setDescription('Remove a track from a playlist')
+                        .addStringOption(option =>
+                            option.setName('name')
+                                .setDescription('Name of the playlist')
+                                .setRequired(true))
+                        .addIntegerOption(option =>
+                            option.setName('index')
+                                .setDescription('Track number to remove')
+                                .setRequired(true)))
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName('delete')
+                        .setDescription('Delete a playlist')
+                        .addStringOption(option =>
+                            option.setName('name')
+                                .setDescription('Name of the playlist')
+                                .setRequired(true)))
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName('list')
+                        .setDescription('List all your playlists'))
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName('view')
+                        .setDescription('View a playlist\'s contents')
+                        .addStringOption(option =>
+                            option.setName('name')
+                                .setDescription('Name of the playlist')
+                                .setRequired(true)))
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName('play')
+                        .setDescription('Play a playlist')
+                        .addStringOption(option =>
+                            option.setName('name')
+                                .setDescription('Name of the playlist')
+                                .setRequired(true))),
             // Fun commands
             new SlashCommandBuilder()
                 .setName('story')

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const ImageProcessor = require('./imageProcessor');
 const CommandManager = require('./commands');
 const { bingSearch } = require('./utils');
 const DiscordBot = require('./bot');
+const MusicModule = require('./music/musicModule');
 
 // Initialize components
 const memoryManager = new MemoryManager();
@@ -12,7 +13,11 @@ const textProcessor = new TextProcessor(memoryManager);
 const imageProcessor = new ImageProcessor(textProcessor);
 const commandManager = new CommandManager(textProcessor, bingSearch);
 const ttsHandler = new TTSHandler();
+const musicModule = new MusicModule(config);
 
 // Create and start the bot
-const bot = new DiscordBot(memoryManager, textProcessor, imageProcessor, commandManager, ttsHandler);
+const bot = new DiscordBot(memoryManager, textProcessor, imageProcessor, commandManager, ttsHandler, musicModule);
+
+// Start both bots
+musicModule.start(config.MUSIC_BOT_TOKEN);
 bot.start();

--- a/src/music/musicModule.js
+++ b/src/music/musicModule.js
@@ -1,0 +1,311 @@
+const { EmbedBuilder } = require('discord.js');
+const { AudioPlayerStatus } = require('@discordjs/voice');
+const MusicWorkerBot = require('./workerBot');
+const TrackInfo = require('./trackInfo');
+const PlaylistManager = require('./playlistManager');
+const play = require('play-dl');
+
+class MusicModule {
+    constructor(config) {
+        this.trackInfo = new TrackInfo(config);
+        this.workerBot = new MusicWorkerBot(this.trackInfo);
+        this.playlistManager = new PlaylistManager();
+        this.config = config;
+    }
+
+    start(token) {
+        this.workerBot.start(token);
+    }
+
+    async handleCommand(interaction, command) {
+        // Voice channel check for music playback commands
+        if (['play', 'skip', 'stop'].includes(command) && !interaction.member.voice.channel) {
+            await interaction.reply('You need to be in a voice channel to use music playback commands!');
+            return;
+        }
+
+        switch (command) {
+            case 'play':
+                await this.handlePlay(interaction);
+                break;
+            case 'skip':
+                await this.handleSkip(interaction);
+                break;
+            case 'stop':
+                await this.handleStop(interaction);
+                break;
+            case 'queue':
+                await this.handleQueue(interaction);
+                break;
+            case 'playlist':
+                await this.handlePlaylistCommand(interaction);
+                break;
+        }
+    }
+
+    async handlePlay(interaction) {
+        await interaction.deferReply();
+
+        const query = interaction.options.getString('query');
+        try {
+            // Connect to voice channel if not already connected
+            if (!this.workerBot.connection) {
+                const connected = await this.workerBot.connectToChannel(
+                    interaction.member.voice.channel.id,
+                    interaction.guildId
+                );
+                if (!connected) {
+                    await interaction.editReply('Failed to join voice channel!');
+                    return;
+                }
+            }
+
+            // Check if it's a playlist URL
+            const isPlaylist = query.includes('/playlist/') || query.includes('list=');
+            const result = await this.workerBot.addToQueue(interaction.guildId, query, isPlaylist);
+
+            if (!result) {
+                await interaction.editReply('No results found!');
+                return;
+            }
+
+            if (isPlaylist) {
+                const embed = this.trackInfo.createPlaylistEmbed(result);
+                await interaction.editReply({ 
+                    content: 'Added playlist to queue!',
+                    embeds: [embed]
+                });
+            } else {
+                const embed = this.trackInfo.createEmbed(result);
+                await interaction.editReply({ 
+                    content: 'Added to queue!',
+                    embeds: [embed]
+                });
+            }
+        } catch (error) {
+            console.error('Error playing music:', error);
+            await interaction.editReply('An error occurred while trying to play the music.');
+        }
+    }
+
+    async handleSkip(interaction) {
+        const remainingTracks = this.workerBot.skipCurrent(interaction.guildId);
+        await interaction.reply(`Skipped current track. ${remainingTracks} tracks remaining in queue.`);
+    }
+
+    async handleStop(interaction) {
+        this.workerBot.clearQueue(interaction.guildId);
+        this.workerBot.disconnect();
+        await interaction.reply('Stopped playback and cleared the queue.');
+    }
+
+    async handleQueue(interaction) {
+        const queue = this.workerBot.queue.get(interaction.guildId) || [];
+        if (queue.length === 0) {
+            await interaction.reply('The queue is empty!');
+            return;
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor('#1DB954')
+            .setTitle('Current Queue')
+            .setDescription(`${queue.length} tracks in queue`);
+
+        // Add current track
+        if (this.workerBot.player.state.status !== AudioPlayerStatus.Idle) {
+            const currentTrack = queue[0];
+            embed.addFields({
+                name: 'Now Playing',
+                value: `${currentTrack.title} - ${currentTrack.artist || 'Unknown'}`
+            });
+        }
+
+        // Add upcoming tracks (up to 10)
+        const upcomingTracks = queue.slice(1, 11)
+            .map((track, index) => `${index + 1}. ${track.title} - ${track.artist || 'Unknown'} (${track.duration})`)
+            .join('\n');
+
+        if (upcomingTracks) {
+            embed.addFields({
+                name: 'Up Next',
+                value: upcomingTracks
+            });
+        }
+
+        // If there are more tracks, add a note
+        if (queue.length > 11) {
+            embed.addFields({
+                name: 'And more...',
+                value: `${queue.length - 11} more tracks in queue`
+            });
+        }
+
+        await interaction.reply({ embeds: [embed] });
+    }
+
+    async handlePlaylistCommand(interaction) {
+        const subcommand = interaction.options.getSubcommand();
+
+        try {
+            switch (subcommand) {
+                case 'create':
+                    await this.handlePlaylistCreate(interaction);
+                    break;
+                case 'add':
+                    await this.handlePlaylistAdd(interaction);
+                    break;
+                case 'remove':
+                    await this.handlePlaylistRemove(interaction);
+                    break;
+                case 'delete':
+                    await this.handlePlaylistDelete(interaction);
+                    break;
+                case 'list':
+                    await this.handlePlaylistList(interaction);
+                    break;
+                case 'view':
+                    await this.handlePlaylistView(interaction);
+                    break;
+                case 'play':
+                    await this.handlePlaylistPlay(interaction);
+                    break;
+            }
+        } catch (error) {
+            console.error('Error handling playlist command:', error);
+            const errorMessage = error.message || 'An error occurred while managing the playlist.';
+            if (!interaction.replied && !interaction.deferred) {
+                await interaction.reply({ content: errorMessage, ephemeral: true });
+            } else {
+                await interaction.editReply({ content: errorMessage, ephemeral: true });
+            }
+        }
+    }
+
+    async handlePlaylistCreate(interaction) {
+        const name = interaction.options.getString('name');
+        const description = interaction.options.getString('description') || '';
+
+        await interaction.deferReply();
+        const playlist = await this.playlistManager.createPlaylist(
+            interaction.user.id,
+            name,
+            description
+        );
+
+        const embed = this.playlistManager.createPlaylistEmbed(playlist);
+        await interaction.editReply({
+            content: 'Playlist created successfully!',
+            embeds: [embed]
+        });
+    }
+
+    async handlePlaylistAdd(interaction) {
+        const name = interaction.options.getString('name');
+        const query = interaction.options.getString('query');
+
+        await interaction.deferReply();
+        
+        // Get track info
+        const trackInfo = await this.trackInfo.getTrackInfo(query);
+        if (!trackInfo) {
+            await interaction.editReply('Could not find the track!');
+            return;
+        }
+
+        // Add to playlist
+        const playlist = await this.playlistManager.addToPlaylist(
+            interaction.user.id,
+            name,
+            trackInfo
+        );
+
+        const embed = this.playlistManager.createPlaylistEmbed(playlist);
+        await interaction.editReply({
+            content: `Added "${trackInfo.title}" to playlist "${name}"!`,
+            embeds: [embed]
+        });
+    }
+
+    async handlePlaylistRemove(interaction) {
+        const name = interaction.options.getString('name');
+        const index = interaction.options.getInteger('index') - 1; // Convert to 0-based index
+
+        await interaction.deferReply();
+        const playlist = await this.playlistManager.removeFromPlaylist(
+            interaction.user.id,
+            name,
+            index
+        );
+
+        const embed = this.playlistManager.createPlaylistEmbed(playlist);
+        await interaction.editReply({
+            content: 'Track removed from playlist!',
+            embeds: [embed]
+        });
+    }
+
+    async handlePlaylistDelete(interaction) {
+        const name = interaction.options.getString('name');
+
+        await interaction.deferReply();
+        await this.playlistManager.deletePlaylist(interaction.user.id, name);
+
+        await interaction.editReply(`Playlist "${name}" has been deleted!`);
+    }
+
+    async handlePlaylistList(interaction) {
+        await interaction.deferReply();
+        const userPlaylists = await this.playlistManager.getUserPlaylists(interaction.user.id);
+        
+        const embed = this.playlistManager.createPlaylistListEmbed(
+            interaction.user.id,
+            userPlaylists.playlists
+        );
+
+        await interaction.editReply({ embeds: [embed] });
+    }
+
+    async handlePlaylistView(interaction) {
+        const name = interaction.options.getString('name');
+
+        await interaction.deferReply();
+        const playlist = await this.playlistManager.getPlaylist(interaction.user.id, name);
+        
+        const embed = this.playlistManager.createPlaylistEmbed(playlist, true);
+        await interaction.editReply({ embeds: [embed] });
+    }
+
+    async handlePlaylistPlay(interaction) {
+        const name = interaction.options.getString('name');
+
+        await interaction.deferReply();
+        
+        // Get the playlist
+        const playlist = await this.playlistManager.getPlaylist(interaction.user.id, name);
+        
+        // Connect to voice channel if not already connected
+        if (!this.workerBot.connection) {
+            const connected = await this.workerBot.connectToChannel(
+                interaction.member.voice.channel.id,
+                interaction.guildId
+            );
+            if (!connected) {
+                await interaction.editReply('Failed to join voice channel!');
+                return;
+            }
+        }
+
+        // Add all tracks to queue
+        for (const track of playlist.tracks) {
+            await this.workerBot.addToQueue(interaction.guildId, track);
+        }
+
+        const embed = this.playlistManager.createPlaylistEmbed(playlist);
+        await interaction.editReply({
+            content: `Playing playlist "${name}"!`,
+            embeds: [embed]
+        });
+    }
+}
+
+module.exports = MusicModule;

--- a/src/music/playlistManager.js
+++ b/src/music/playlistManager.js
@@ -1,0 +1,224 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { EmbedBuilder } = require('discord.js');
+
+class PlaylistManager {
+    constructor() {
+        this.playlistsDir = path.join(__dirname, '../../data/playlists');
+        this.initializeStorage();
+    }
+
+    async initializeStorage() {
+        try {
+            await fs.mkdir(this.playlistsDir, { recursive: true });
+        } catch (error) {
+            console.error('Error creating playlists directory:', error);
+        }
+    }
+
+    async getUserPlaylists(userId) {
+        try {
+            const userFile = path.join(this.playlistsDir, `${userId}.json`);
+            try {
+                const data = await fs.readFile(userFile, 'utf8');
+                return JSON.parse(data);
+            } catch (error) {
+                // If file doesn't exist, return empty playlists object
+                return { playlists: {} };
+            }
+        } catch (error) {
+            console.error('Error reading user playlists:', error);
+            return { playlists: {} };
+        }
+    }
+
+    async saveUserPlaylists(userId, playlists) {
+        try {
+            const userFile = path.join(this.playlistsDir, `${userId}.json`);
+            await fs.writeFile(userFile, JSON.stringify(playlists, null, 2));
+        } catch (error) {
+            console.error('Error saving user playlists:', error);
+            throw error;
+        }
+    }
+
+    async createPlaylist(userId, name, description = '') {
+        try {
+            const userPlaylists = await this.getUserPlaylists(userId);
+            
+            if (userPlaylists.playlists[name]) {
+                throw new Error('A playlist with this name already exists');
+            }
+
+            userPlaylists.playlists[name] = {
+                name,
+                description,
+                tracks: [],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString()
+            };
+
+            await this.saveUserPlaylists(userId, userPlaylists);
+            return userPlaylists.playlists[name];
+        } catch (error) {
+            console.error('Error creating playlist:', error);
+            throw error;
+        }
+    }
+
+    async addToPlaylist(userId, playlistName, track) {
+        try {
+            const userPlaylists = await this.getUserPlaylists(userId);
+            
+            if (!userPlaylists.playlists[playlistName]) {
+                throw new Error('Playlist not found');
+            }
+
+            // Check for duplicates
+            const isDuplicate = userPlaylists.playlists[playlistName].tracks.some(
+                t => t.url === track.url
+            );
+
+            if (!isDuplicate) {
+                userPlaylists.playlists[playlistName].tracks.push(track);
+                userPlaylists.playlists[playlistName].updatedAt = new Date().toISOString();
+                await this.saveUserPlaylists(userId, userPlaylists);
+            }
+
+            return userPlaylists.playlists[playlistName];
+        } catch (error) {
+            console.error('Error adding to playlist:', error);
+            throw error;
+        }
+    }
+
+    async removeFromPlaylist(userId, playlistName, index) {
+        try {
+            const userPlaylists = await this.getUserPlaylists(userId);
+            
+            if (!userPlaylists.playlists[playlistName]) {
+                throw new Error('Playlist not found');
+            }
+
+            if (index < 0 || index >= userPlaylists.playlists[playlistName].tracks.length) {
+                throw new Error('Invalid track index');
+            }
+
+            userPlaylists.playlists[playlistName].tracks.splice(index, 1);
+            userPlaylists.playlists[playlistName].updatedAt = new Date().toISOString();
+            await this.saveUserPlaylists(userId, userPlaylists);
+
+            return userPlaylists.playlists[playlistName];
+        } catch (error) {
+            console.error('Error removing from playlist:', error);
+            throw error;
+        }
+    }
+
+    async deletePlaylist(userId, playlistName) {
+        try {
+            const userPlaylists = await this.getUserPlaylists(userId);
+            
+            if (!userPlaylists.playlists[playlistName]) {
+                throw new Error('Playlist not found');
+            }
+
+            delete userPlaylists.playlists[playlistName];
+            await this.saveUserPlaylists(userId, userPlaylists);
+        } catch (error) {
+            console.error('Error deleting playlist:', error);
+            throw error;
+        }
+    }
+
+    async getPlaylist(userId, playlistName) {
+        try {
+            const userPlaylists = await this.getUserPlaylists(userId);
+            
+            if (!userPlaylists.playlists[playlistName]) {
+                throw new Error('Playlist not found');
+            }
+
+            return userPlaylists.playlists[playlistName];
+        } catch (error) {
+            console.error('Error getting playlist:', error);
+            throw error;
+        }
+    }
+
+    createPlaylistEmbed(playlist, detailed = false) {
+        const embed = new EmbedBuilder()
+            .setColor('#1DB954')
+            .setTitle(playlist.name)
+            .setDescription(playlist.description || 'No description')
+            .addFields(
+                { name: 'Track Count', value: playlist.tracks.length.toString() },
+                { name: 'Last Updated', value: new Date(playlist.updatedAt).toLocaleDateString() }
+            );
+
+        if (detailed && playlist.tracks.length > 0) {
+            // Show all tracks in the playlist
+            const tracksList = playlist.tracks
+                .map((track, index) => `${index + 1}. ${track.title} - ${track.artist || 'Unknown'}`)
+                .join('\n');
+
+            // Split tracks into chunks if needed (Discord has a 1024 character limit per field)
+            const chunks = this.chunkString(tracksList, 1024);
+            chunks.forEach((chunk, index) => {
+                embed.addFields({
+                    name: index === 0 ? 'Tracks' : '⠀', // Empty character for additional fields
+                    value: chunk
+                });
+            });
+        } else if (playlist.tracks.length > 0) {
+            // Show only first 5 tracks
+            const tracksList = playlist.tracks
+                .slice(0, 5)
+                .map((track, index) => `${index + 1}. ${track.title} - ${track.artist || 'Unknown'}`)
+                .join('\n');
+
+            embed.addFields({ name: 'Sample Tracks', value: tracksList });
+
+            if (playlist.tracks.length > 5) {
+                embed.addFields({
+                    name: 'And more...',
+                    value: `${playlist.tracks.length - 5} more tracks`
+                });
+            }
+        }
+
+        return embed;
+    }
+
+    createPlaylistListEmbed(userId, playlists) {
+        const embed = new EmbedBuilder()
+            .setColor('#1DB954')
+            .setTitle('Your Playlists')
+            .setDescription(`You have ${Object.keys(playlists).length} playlists`);
+
+        if (Object.keys(playlists).length > 0) {
+            const playlistsList = Object.values(playlists)
+                .map(playlist => `**${playlist.name}** - ${playlist.tracks.length} tracks`)
+                .join('\n');
+
+            embed.addFields({ name: 'Playlists', value: playlistsList });
+        } else {
+            embed.addFields({
+                name: 'No Playlists',
+                value: 'Create a playlist using /playlist create'
+            });
+        }
+
+        return embed;
+    }
+
+    chunkString(str, size) {
+        const chunks = [];
+        for (let i = 0; i < str.length; i += size) {
+            chunks.push(str.slice(i, i + size));
+        }
+        return chunks;
+    }
+}
+
+module.exports = PlaylistManager;

--- a/src/music/trackInfo.js
+++ b/src/music/trackInfo.js
@@ -1,0 +1,228 @@
+const { EmbedBuilder } = require('discord.js');
+const SpotifyWebApi = require('spotify-web-api-node');
+const play = require('play-dl');
+
+class TrackInfo {
+    constructor(config) {
+        this.spotify = new SpotifyWebApi({
+            clientId: config.SPOTIFY_CLIENT_ID,
+            clientSecret: config.SPOTIFY_CLIENT_SECRET
+        });
+        this.initializeSpotify();
+    }
+
+    async initializeSpotify() {
+        try {
+            const data = await this.spotify.clientCredentialsGrant();
+            this.spotify.setAccessToken(data.body.access_token);
+
+            // Refresh token periodically
+            setInterval(async () => {
+                const data = await this.spotify.clientCredentialsGrant();
+                this.spotify.setAccessToken(data.body.access_token);
+            }, (data.body.expires_in - 60) * 1000);
+        } catch (error) {
+            console.error('Failed to initialize Spotify:', error);
+        }
+    }
+
+    createEmbed(trackInfo) {
+        const embed = new EmbedBuilder()
+            .setColor('#1DB954')
+            .setTitle(trackInfo.title)
+            .setURL(trackInfo.url);
+
+        if (trackInfo.thumbnail) {
+            embed.setThumbnail(trackInfo.thumbnail);
+        }
+
+        if (trackInfo.artist) {
+            embed.addFields({ name: 'Artist', value: trackInfo.artist });
+        }
+
+        if (trackInfo.duration) {
+            embed.addFields({ name: 'Duration', value: trackInfo.duration });
+        }
+
+        if (trackInfo.source) {
+            embed.setFooter({ text: `Source: ${trackInfo.source}` });
+        }
+
+        return embed;
+    }
+
+    async getTrackInfo(query) {
+        // Check if it's a Spotify URL
+        if (query.includes('spotify.com')) {
+            return await this.getSpotifyTrackInfo(query);
+        }
+
+        // Check if it's a YouTube URL or search query
+        try {
+            const searchResult = await play.search(query, { limit: 1 });
+            if (!searchResult || searchResult.length === 0) return null;
+
+            const video = searchResult[0];
+            return {
+                title: video.title,
+                artist: video.channel.name,
+                duration: video.durationRaw,
+                thumbnail: video.thumbnails[0].url,
+                url: video.url,
+                source: 'YouTube'
+            };
+        } catch (error) {
+            console.error('Error getting track info:', error);
+            return null;
+        }
+    }
+
+    async getSpotifyTrackInfo(url) {
+        try {
+            const trackId = url.split('/track/')[1].split('?')[0];
+            const track = await this.spotify.getTrack(trackId);
+            
+            return {
+                title: track.body.name,
+                artist: track.body.artists.map(a => a.name).join(', '),
+                duration: this.formatDuration(track.body.duration_ms),
+                thumbnail: track.body.album.images[0].url,
+                url: track.body.external_urls.spotify,
+                source: 'Spotify'
+            };
+        } catch (error) {
+            console.error('Error getting Spotify track info:', error);
+            return null;
+        }
+    }
+
+    async getPlaylistInfo(url) {
+        if (url.includes('spotify.com')) {
+            return await this.getSpotifyPlaylistInfo(url);
+        } else if (url.includes('youtube.com')) {
+            return await this.getYouTubePlaylistInfo(url);
+        }
+        return null;
+    }
+
+    async getSpotifyPlaylistInfo(url) {
+        try {
+            const playlistId = url.split('/playlist/')[1].split('?')[0];
+            const playlist = await this.spotify.getPlaylist(playlistId);
+            const tracks = await this.getSpotifyPlaylistTracks(playlistId);
+
+            return {
+                title: playlist.body.name,
+                description: playlist.body.description,
+                thumbnail: playlist.body.images[0].url,
+                url: playlist.body.external_urls.spotify,
+                trackCount: playlist.body.tracks.total,
+                tracks: tracks,
+                source: 'Spotify'
+            };
+        } catch (error) {
+            console.error('Error getting Spotify playlist info:', error);
+            return null;
+        }
+    }
+
+    async getSpotifyPlaylistTracks(playlistId) {
+        const tracks = [];
+        let offset = 0;
+        const limit = 100;
+
+        while (true) {
+            try {
+                const response = await this.spotify.getPlaylistTracks(playlistId, { offset, limit });
+                const items = response.body.items;
+                
+                if (items.length === 0) break;
+
+                tracks.push(...items.map(item => ({
+                    title: item.track.name,
+                    artist: item.track.artists.map(a => a.name).join(', '),
+                    duration: this.formatDuration(item.track.duration_ms),
+                    url: item.track.external_urls.spotify
+                })));
+
+                if (items.length < limit) break;
+                offset += limit;
+            } catch (error) {
+                console.error('Error getting playlist tracks:', error);
+                break;
+            }
+        }
+
+        return tracks;
+    }
+
+    async getYouTubePlaylistInfo(url) {
+        try {
+            const playlist = await play.playlist_info(url);
+            const videos = await playlist.all_videos();
+
+            return {
+                title: playlist.title,
+                description: playlist.description?.substring(0, 100) + '...',
+                thumbnail: playlist.thumbnail?.url,
+                url: playlist.url,
+                trackCount: videos.length,
+                tracks: videos.map(video => ({
+                    title: video.title,
+                    artist: video.channel.name,
+                    duration: video.durationRaw,
+                    url: video.url
+                })),
+                source: 'YouTube'
+            };
+        } catch (error) {
+            console.error('Error getting YouTube playlist info:', error);
+            return null;
+        }
+    }
+
+    createPlaylistEmbed(playlistInfo) {
+        const embed = new EmbedBuilder()
+            .setColor('#1DB954')
+            .setTitle(playlistInfo.title)
+            .setURL(playlistInfo.url)
+            .setDescription(playlistInfo.description || 'No description available')
+            .addFields(
+                { name: 'Track Count', value: playlistInfo.trackCount.toString() },
+                { name: 'Source', value: playlistInfo.source }
+            );
+
+        if (playlistInfo.thumbnail) {
+            embed.setThumbnail(playlistInfo.thumbnail);
+        }
+
+        // Add a sample of tracks (first 5)
+        const trackList = playlistInfo.tracks
+            .slice(0, 5)
+            .map((track, index) => `${index + 1}. ${track.title} - ${track.artist}`)
+            .join('\n');
+
+        if (trackList) {
+            embed.addFields({ name: 'Sample Tracks', value: trackList });
+        }
+
+        if (playlistInfo.tracks.length > 5) {
+            embed.addFields({ name: 'And more...', value: `${playlistInfo.tracks.length - 5} more tracks` });
+        }
+
+        return embed;
+    }
+
+    formatDuration(ms) {
+        const seconds = Math.floor((ms / 1000) % 60);
+        const minutes = Math.floor((ms / (1000 * 60)) % 60);
+        const hours = Math.floor(ms / (1000 * 60 * 60));
+
+        if (hours > 0) {
+            return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        }
+        return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+    }
+}
+
+module.exports = TrackInfo;

--- a/src/music/workerBot.js
+++ b/src/music/workerBot.js
@@ -1,0 +1,124 @@
+const { Client, GatewayIntentBits } = require('discord.js');
+const { joinVoiceChannel, createAudioPlayer, createAudioResource, AudioPlayerStatus } = require('@discordjs/voice');
+const { config } = require('../config');
+const play = require('play-dl');
+
+class MusicWorkerBot {
+    constructor(trackInfo) {
+        this.trackInfo = trackInfo;
+        this.client = new Client({
+            intents: [
+                GatewayIntentBits.Guilds,
+                GatewayIntentBits.GuildVoiceStates,
+            ]
+        });
+
+        this.player = createAudioPlayer();
+        this.queue = new Map();
+        this.connection = null;
+        
+        this.setupEventHandlers();
+    }
+
+    setupEventHandlers() {
+        this.client.on('ready', () => {
+            console.log(`Music Worker Bot logged in as ${this.client.user.tag}!`);
+        });
+
+        this.player.on(AudioPlayerStatus.Idle, () => {
+            this.playNext();
+        });
+
+        this.player.on('error', error => {
+            console.error('Error:', error.message);
+            this.playNext();
+        });
+    }
+
+    async connectToChannel(channelId, guildId) {
+        const guild = this.client.guilds.cache.get(guildId);
+        const channel = guild.channels.cache.get(channelId);
+
+        if (!channel) return false;
+
+        this.connection = joinVoiceChannel({
+            channelId: channel.id,
+            guildId: channel.guild.id,
+            adapterCreator: channel.guild.voiceAdapterCreator,
+        });
+
+        this.connection.subscribe(this.player);
+        return true;
+    }
+
+    async addToQueue(guildId, query, isPlaylist = false) {
+        if (!this.queue.has(guildId)) {
+            this.queue.set(guildId, []);
+        }
+
+        if (isPlaylist) {
+            const playlistInfo = await this.trackInfo.getPlaylistInfo(query);
+            if (!playlistInfo) return null;
+
+            // Add all tracks from playlist to queue
+            this.queue.get(guildId).push(...playlistInfo.tracks);
+
+            if (this.player.state.status === AudioPlayerStatus.Idle) {
+                this.playNext(guildId);
+            }
+
+            return playlistInfo;
+        } else {
+            const trackInfo = await this.trackInfo.getTrackInfo(query);
+            if (!trackInfo) return null;
+
+            this.queue.get(guildId).push(trackInfo);
+
+            if (this.player.state.status === AudioPlayerStatus.Idle) {
+                this.playNext(guildId);
+            }
+
+            return trackInfo;
+        }
+    }
+
+    async playNext(guildId) {
+        const queue = this.queue.get(guildId);
+        if (!queue || queue.length === 0) return;
+
+        const track = queue.shift();
+        try {
+            const stream = await play.stream(track.url);
+            const resource = createAudioResource(stream.stream, {
+                inputType: stream.type
+            });
+            this.player.play(resource);
+        } catch (error) {
+            console.error('Error playing track:', error);
+            this.playNext(guildId);
+        }
+    }
+
+    skipCurrent(guildId) {
+        this.player.stop();
+        return this.queue.get(guildId)?.length || 0;
+    }
+
+    clearQueue(guildId) {
+        this.queue.set(guildId, []);
+        this.player.stop();
+    }
+
+    disconnect() {
+        if (this.connection) {
+            this.connection.destroy();
+            this.connection = null;
+        }
+    }
+
+    start(token) {
+        this.client.login(token);
+    }
+}
+
+module.exports = MusicWorkerBot;


### PR DESCRIPTION
This PR adds a complete music system with playlist management:

### Features
- Separate worker bot for music playback
- User playlist management with persistent storage
- Rich embeds for tracks and playlists
- Spotify integration
- YouTube playlist support

### New Commands
- `/playlist create <name> [description]` - Create a new playlist
- `/playlist add <name> <query>` - Add a track to a playlist
- `/playlist remove <name> <index>` - Remove a track from a playlist
- `/playlist delete <name>` - Delete a playlist
- `/playlist list` - List all your playlists
- `/playlist view <name>` - View a playlist's contents
- `/playlist play <name>` - Play a playlist

### Technical Details
- Playlists stored in JSON format per user
- Automatic track info fetching
- Duplicate track prevention
- Error handling with user-friendly messages

### Required Configuration
- Add `MUSIC_BOT_TOKEN` for the worker bot
- Add `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` for Spotify integration

### Dependencies Added
- `play-dl` for YouTube streaming
- `spotify-web-api-node` for Spotify integration